### PR TITLE
Fix spelling mistakes, use a Python library for ngrok

### DIFF
--- a/MineColab.ipynb
+++ b/MineColab.ipynb
@@ -5,10 +5,7 @@
     "colab": {
       "name": "MineColab",
       "provenance": [],
-      "collapsed_sections": [],
-      "mount_file_id": "1Fz6IkpzUN9vL35BVRUr92gwZ3BaiKvps",
-      "authorship_tag": "ABX9TyPgXKnuS5OuzGIOBWd/Qx8r",
-      "include_colab_link": true
+      "collapsed_sections": []
     },
     "kernelspec": {
       "name": "python3",
@@ -19,18 +16,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/thecoder-001/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZktjRJuZp1h6",
-        "colab_type": "text"
+        "id": "ZktjRJuZp1h6"
       },
       "source": [
         "```\n",
@@ -47,49 +33,38 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "lqtMoYg0dUmu",
-        "colab_type": "code",
-        "colab": {}
+        "id": "lqtMoYg0dUmu"
       },
       "source": [
-        "import os\n",
-        "#update the system\n",
-        "!sudo apt update\n",
-        "#Install OpenJDK 11 & tmux\n",
-        "!sudo apt-get install openjdk-11-jdk tmux\n",
+        "!pip install pyngrok\n",
         "\n",
-        "#Mount Google Drive by giving permission\n",
+        "import os\n",
+        "from pyngrok import ngrok\n",
+        "# Update the package lists\n",
+        "!sudo apt update\n",
+        "# Install OpenJDK 11\n",
+        "!sudo apt-get install openjdk-11-jre\n",
+        "\n",
+        "# Mount Google Drive\n",
         "from google.colab import drive\n",
         "drive.mount('/content/drive')\n",
         "\n",
-        "#Download Ngrok\n",
-        "! wget -q -c -nc https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip\n",
-        "! unzip -qq -n ngrok-stable-linux-amd64.zip\n",
-        "#Ask token\n",
+        "# Ask for the ngrok authtoken\n",
         "print(\"Get your authtoken from https://dashboard.ngrok.com/auth\")\n",
         "import getpass\n",
-        "authtoken = getpass.getpass()  #input your Ngrok auth token everytime or simply replace \"getpass.getpass()\" with your token in \"double quotes\"\n",
-        "get_ipython().system_raw('./ngrok authtoken $authtoken && ./ngrok tcp 25565 &') #Create tunnel with port 25565\n",
+        "authtoken = getpass.getpass()  # input your Ngrok auth token everytime you run the cell or simply replace \"getpass.getpass()\" with your token in \"double quotes\"\n",
+        "! ngrok authtoken $authtoken # login to ngrok\n",
         "\n",
-        "#change directory to the Minecraft server folder on Google Drive\n",
+        "# Connect to ngrok\n",
+        "url = ngrok.connect(25565, 'tcp')\n",
+        "print('Your server address is ' + url.replace('tcp://', ''))\n",
+        "\n",
+        "# Change directory to the Minecraft server folder on Google Drive\n",
         "%cd \"/content/drive/My Drive/Minecraft-server\"\n",
-        "!ls #list the directory contents (to verify that working directory was changed)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "SNAAPbiVmf4X",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "## Start the Server ##\n",
-        "!java -Xmx6144M -Xms6144M -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar server.jar nogui\n",
+        "!ls #list the directory contents (to verify that working directory was changed)\n",
         "\n",
-        "\n"
+        "print('Starting server...')\n",
+        "!java -Xmx6144M -Xms6144M -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -jar server.jar nogui\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -97,8 +72,28 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "FO5S4OHVdV5O",
-        "colab_type": "text"
+        "id": "vhHYrg6FlbcQ"
+      },
+      "source": [
+        "**Automatically accept the EULA**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "aefCB6cFlle8"
+      },
+      "source": [
+        "%cd \"/content/drive/My Drive/Minecraft-server\"\n",
+        "! sed -i 's/eula=false/eula=true/g' eula.txt"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FO5S4OHVdV5O"
       },
       "source": [
         "# Debug\n",
@@ -108,9 +103,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "cM7gKp6Yi8Q2",
-        "colab_type": "code",
-        "colab": {}
+        "id": "cM7gKp6Yi8Q2"
       },
       "source": [
         "## For SSH acess to host OS ##\n",
@@ -149,12 +142,10 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Z2rztsCQk0kh",
-        "colab_type": "code",
-        "colab": {}
+        "id": "Z2rztsCQk0kh"
       },
       "source": [
-        "## For enspecting the minecraft server directory ##\n",
+        "## For inspecting the minecraft server directory ##\n",
         "%cd \"/content/drive/My Drive/Minecraft-server\"\n",
         "!ls\n"
       ],

--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ Yes, Colab is free to use. But there are some points which, according to me one 
 
 In the end, it is just my personal opinion and can be ignored safely. Just ask your heart whats right and whats wrong. Also, please try to use it as a once in a while resource and not 24x7 so that others can avail the free resources too.
 ## :zap:  So, how does it actually work?
-As Goolgle Colab is a vm instance running Ubuntu server as base OS, it can be easily used as a minecraft server. Here are the steps which the notebook performs to setup the server:
+As Google Colab is a VM running Ubuntu server as base OS, it can be easily used as a Minecraft server. Here are the steps which the notebook performs to setup the server:
 1. Update the system's apt cache.
 2. Install Openjdk-11 (Java) through apt-get.
 3. Mount Google Drive to access the minecraft folder (Drive is used here to provide persistent storage).
-4. Download Ngrok (for setting up a port tunnel).
-5. Setup Ngrok (by asking for key by user and opening a tunnel at port 25565).
-6. Change directory to the minecraft-server folder on google drive (I have here used "Minecraft-server" as the server folder in the root directory of my Google Drive.
-7. List/Print the file list on the screen to indicate succesful directory change.
-8. Startup the Minecraft server (with optimized JVM parameters from <a href="https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/">Aikar's guide</a>)
+4. Setup Ngrok (by asking for key by user and opening a tunnel at port 25565).
+5. Change directory to the minecraft-server folder on google drive (I have here used "Minecraft-server" as the server folder in the root directory of my Google Drive.
+6. List/Print the file list on the screen to indicate succesful directory change.
+7. Startup the Minecraft server (with optimized JVM parameters from [Aikar's guide)](https://aikar.co/2018/07/02/tuning-the-jvm-g1gc-garbage-collector-flags-for-minecraft/)
 
+## 👍 Tips
+- Use [RaiDrive](https://www.raidrive.com/) to manage your server's files
 
 [![ForTheBadge built-with-love](http://ForTheBadge.com/images/badges/built-with-love.svg)](https://github.com/thecoder-001)
 


### PR DESCRIPTION
Looks like we made changes at the same time, which means some conflicts will have to be resolved :P

More details:
- `tmux` is no longer installed because it is unused
- `openjdk-11-jre` is used instead of `openjdk-11-jdk`. It's the same thing without tools that are used to compile Java apps
- `pyngrok` is used to connect to ngrok
- everything is started in a single cell

I also wrote a script that automatically accepts the EULA (which is somewhat hard to do in Google Drive without 3rd-party apps)