### PR TITLE
Speed up initial setup for Argo users

### DIFF
--- a/MineColab.ipynb
+++ b/MineColab.ipynb
@@ -81,7 +81,7 @@
         "tunnel_service = \"argo\"\n",
         "\n",
         "if tunnel_service == \"ngrok\":\n",
-        "  os.system(\"pip install pyngrok\")\n",
+        "  !pip -q install pyngrok\n",
         "  from pyngrok import conf, ngrok\n",
         "  \n",
         "  # Ask for the ngrok authtoken\n",


### PR DESCRIPTION
This ensures that `pip install pyngrok` only runs if the user wants to make use of ngrok which speeds up the initial setup for argo users who don't need it.