### PR TITLE
Update api usage for paper to v2

### DIFF
--- a/MineColab.ipynb
+++ b/MineColab.ipynb
@@ -3,10 +3,9 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "MineColab",
+      "name": "Copy of MineColab",
       "provenance": [],
-      "collapsed_sections": [],
-      "include_colab_link": true
+      "collapsed_sections": []
     },
     "kernelspec": {
       "name": "python3",
@@ -14,16 +13,6 @@
     }
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/thecoder-001/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -155,7 +144,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Fy5-YjJMPV3S"
+        "id": "Fy5-YjJMPV3S",
+        "outputId": "28685a2a-61a2-4579-c5ac-c9a3b5698a53",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "# Replace \"1.17\" with your desired server version.\n",
@@ -195,9 +188,19 @@
         "%cd \"/content/drive/My Drive/Minecraft-server\"\n",
         "\n",
         "# Internal init...\n",
+        "\n",
+        "\n",
+        "a = requests.get(\"https://papermc.io/api/v2/projects/paper/versions/\" + version)\n",
+        "#print(a.json()[\"builds\"][-1])\n",
+        "b = requests.get(\"https://papermc.io/api/v2/projects/paper/versions/\" + version + \"/builds/\" + str(a.json()[\"builds\"][-1]))\n",
+        "#print(b.json()[\"downloads\"][\"application\"][\"name\"])\n",
+        "print(\"https://papermc.io/api/v2/projects/paper/versions/\" + version + \"/builds/\" + str(a.json()[\"builds\"][-1]) + \"/downloads/\" + b.json()[\"downloads\"][\"application\"][\"name\"])\n",
+        "\n",
+        "paperURL = \"https://papermc.io/api/v2/projects/paper/versions/\" + version + \"/builds/\" + str(a.json()[\"builds\"][-1]) + \"/downloads/\" + b.json()[\"downloads\"][\"application\"][\"name\"]\n",
+        "\n",
         "jar_name = {'paper': 'server.jar', 'fabric': 'fabric-installer.jar'}\n",
         "url = {\n",
-        "    'paper': ('https://papermc.io/api/v1/paper/' + version + '/latest/download'),\n",
+        "    'paper': (paperURL),\n",
         "    'fabric': 'https://maven.fabricmc.net/net/fabricmc/fabric-installer/0.7.4/fabric-installer-0.7.4.jar'\n",
         "    }\n",
         "\n",
@@ -222,7 +225,19 @@
         "print('Done!') # todo: Would show even after erroring.\n"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Mounted at /content/drive\n",
+            "/content/drive/My Drive/Minecraft-server\n",
+            "https://papermc.io/api/v2/projects/paper/versions/1.17.1/builds/406/downloads/paper-1.17.1-406.jar\n",
+            "Downloading to Google Drive...\n",
+            "Done!\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "markdown",

--- a/MineColab.ipynb
+++ b/MineColab.ipynb
@@ -21,7 +21,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/turtleship69/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/thecoder-001/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -155,10 +155,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Fy5-YjJMPV3S",
-        "outputId": "28685a2a-61a2-4579-c5ac-c9a3b5698a53",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
+        "id": "Fy5-YjJMPV3S"
         }
       },
       "source": [
@@ -236,17 +233,7 @@
         "print('Done!') # todo: Would show even after erroring.\n"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Mounted at /content/drive\n",
-            "/content/drive/My Drive/Minecraft-server\n",
-            "https://papermc.io/api/v2/projects/paper/versions/1.17.1/builds/406/downloads/paper-1.17.1-406.jar\n",
-            "Downloading to Google Drive...\n",
-            "Done!\n"
-          ]
+      "outputs": []
         }
       ]
     },

--- a/MineColab.ipynb
+++ b/MineColab.ipynb
@@ -21,7 +21,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/thecoder-001/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/turtleship69/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -156,7 +156,6 @@
       "cell_type": "code",
       "metadata": {
         "id": "Fy5-YjJMPV3S"
-        }
       },
       "source": [
         "# Replace \"1.17\" with your desired server version.\n",
@@ -234,8 +233,6 @@
       ],
       "execution_count": null,
       "outputs": []
-        }
-      ]
     },
     {
       "cell_type": "markdown",

--- a/MineColab.ipynb
+++ b/MineColab.ipynb
@@ -21,7 +21,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/turtleship69/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/thecoder-001/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/MineColab.ipynb
+++ b/MineColab.ipynb
@@ -3,9 +3,10 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Copy of MineColab",
+      "name": "MineColab",
       "provenance": [],
-      "collapsed_sections": []
+      "collapsed_sections": [],
+      "include_colab_link": true
     },
     "kernelspec": {
       "name": "python3",
@@ -13,6 +14,16 @@
     }
   },
   "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/turtleship69/MineColab/blob/master/MineColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
     {
       "cell_type": "markdown",
       "metadata": {


### PR DESCRIPTION
god google colab doesn't play nicely with github.  
I've tested the download, as well as servers made with a server.jar obtained from the obtained download link.  